### PR TITLE
fix(core): Rename package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stackbuilders/semantic-release-hackage",
+  "name": "semantic-release-hackage",
   "version": "0.0.0",
   "description": "A semantic-release plugin to publish Haskell packages to Hackage",
   "repository": "git@github.com:stackbuilders/semantic-release-hackage.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,39 +807,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stackbuilders/semantic-release-hackage@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "@stackbuilders/semantic-release-hackage@workspace:."
-  dependencies:
-    "@assertive-ts/core": "npm:^2.0.0"
-    "@types/mocha": "npm:^10.0.6"
-    "@types/semantic-release": "npm:^20.0.6"
-    "@types/signale": "npm:^1.4.7"
-    "@types/sinon": "npm:^17.0.3"
-    "@typescript-eslint/eslint-plugin": "npm:^6.20.0"
-    "@typescript-eslint/parser": "npm:^6.20.0"
-    axios: "npm:^1.6.7"
-    axios-mock-adapter: "npm:^1.22.0"
-    eslint: "npm:^8.56.0"
-    eslint-import-resolver-typescript: "npm:^3.6.1"
-    eslint-plugin-etc: "npm:^2.0.3"
-    eslint-plugin-import: "npm:^2.29.1"
-    eslint-plugin-jsdoc: "npm:^48.0.4"
-    eslint-plugin-sonarjs: "npm:^0.23.0"
-    mocha: "npm:^10.2.0"
-    semantic-release: "npm:^23.0.0"
-    semantic-release-yarn: "npm:^3.0.2"
-    sinon: "npm:^17.0.1"
-    ts-node: "npm:^10.9.2"
-    typescript: "npm:^5.3.3"
-  peerDependencies:
-    semantic-release: ">=22.0.0"
-  peerDependenciesMeta:
-    semantic-release:
-      optional: false
-  languageName: unknown
-  linkType: soft
-
 "@tsconfig/node10@npm:^1.0.7":
   version: 1.0.9
   resolution: "@tsconfig/node10@npm:1.0.9"
@@ -5649,6 +5616,39 @@ __metadata:
   checksum: 7eaf7a0cf37cc27b42fb3ef6a9b1df6e93a1c6d98c6c6702b02fe262d5fcbd89db63320793b99b21cb5348097d0a53de81bd5f4e8b86e20cc9412e3f1cfb4e83
   languageName: node
   linkType: hard
+
+"semantic-release-hackage@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "semantic-release-hackage@workspace:."
+  dependencies:
+    "@assertive-ts/core": "npm:^2.0.0"
+    "@types/mocha": "npm:^10.0.6"
+    "@types/semantic-release": "npm:^20.0.6"
+    "@types/signale": "npm:^1.4.7"
+    "@types/sinon": "npm:^17.0.3"
+    "@typescript-eslint/eslint-plugin": "npm:^6.20.0"
+    "@typescript-eslint/parser": "npm:^6.20.0"
+    axios: "npm:^1.6.7"
+    axios-mock-adapter: "npm:^1.22.0"
+    eslint: "npm:^8.56.0"
+    eslint-import-resolver-typescript: "npm:^3.6.1"
+    eslint-plugin-etc: "npm:^2.0.3"
+    eslint-plugin-import: "npm:^2.29.1"
+    eslint-plugin-jsdoc: "npm:^48.0.4"
+    eslint-plugin-sonarjs: "npm:^0.23.0"
+    mocha: "npm:^10.2.0"
+    semantic-release: "npm:^23.0.0"
+    semantic-release-yarn: "npm:^3.0.2"
+    sinon: "npm:^17.0.1"
+    ts-node: "npm:^10.9.2"
+    typescript: "npm:^5.3.3"
+  peerDependencies:
+    semantic-release: ">=22.0.0"
+  peerDependenciesMeta:
+    semantic-release:
+      optional: false
+  languageName: unknown
+  linkType: soft
 
 "semantic-release-yarn@npm:^3.0.2":
   version: 3.0.2


### PR DESCRIPTION
This PR renames the package to move it out of the `@stackbuilders` namespace since the NPM_TOKEN we use is not associated with that namespace anymore