### PR TITLE
fix(publish): Publish candidate to hackage

### DIFF
--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -22,14 +22,8 @@ export const prepare = async (
   const realCwd = cwd ?? process.cwd();
   logger.log("Current working directory: ", realCwd);
   const cabalFileName = cabalFile ?? lookupCabalFilename(realCwd, logger);
-  const { version } = nextRelease ?? {};
-
-  logger.log("Checking new version");
-  if (!version) {
-    throw new Error("Could not determine the version from semantic release. Check the plugin configuration");
-  }
-
-  logger.log("Checking cabal file");
+  const { version } = nextRelease;
+  logger.log("New version: ", version);
   const fullCabalPath = resolve(realCwd, cabalFileName);
   const fullVersion = `${versionPrefix}${version}`;
   logger.log("Reading .cabal file", fullCabalPath);

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -1,18 +1,11 @@
 import axios from "axios";
-import { BaseContext } from "semantic-release";
+import { PublishContext } from "semantic-release";
 
 import { PluginConfig } from "./types/pluginConfig";
-import { runExecCommand } from "./utils/exec";
 
-export const HACKAGE_PACKAGES_URL = "https://hackage.haskell.org/package";
-export const CANDIDATES_PATH = "candidates/";
+export const HACKAGE_CANDIDATES_URL = "https://hackage.haskell.org/packages/candidates";
 
-export const postReleaseCandidate = async (
-  sdistPath: string,
-  packageName: string,
-  hackageToken?: string,
-): Promise<number | undefined> => {
-  const url = `${HACKAGE_PACKAGES_URL}/${packageName}/${CANDIDATES_PATH}`;
+export const postReleaseCandidate = async (sdistPath: string, hackageToken?: string): Promise<number | undefined> => {
   try {
     const headers = {
       Accept: "text/plain",
@@ -22,25 +15,29 @@ export const postReleaseCandidate = async (
     const formData = new FormData();
     formData.append("package", sdistPath);
 
-    const req = await axios.post(url, formData, { headers });
+    const req = await axios.post(HACKAGE_CANDIDATES_URL, formData, { headers });
 
     return req.status;
   } catch (e: unknown) {
-    throw e instanceof Error ? new Error(`You do not have access to POST a file to ${url}, ${e.message}`) : e;
+    throw e instanceof Error
+      ? new Error(`You do not have access to POST a file to ${HACKAGE_CANDIDATES_URL} , ${e.message}`)
+      : e;
   }
 };
 
-export const publish = async ({ packageName }: PluginConfig, { logger }: BaseContext): Promise<void> => {
-  logger.log("Getting sdist path");
-  const { error, output } = await runExecCommand(`ls dist-newstyle/sdist/${packageName}-*.tar.gz`);
-
-  if (error) {
-    logger.error(error);
-    throw new Error(error);
-  }
+export const publish = async (
+  { packageName, versionPrefix }: PluginConfig,
+  { logger, nextRelease, cwd }: PublishContext,
+): Promise<void> => {
+  const realCwd = cwd ?? process.cwd();
+  logger.log("Current working directory: ", realCwd);
+  const { version } = nextRelease;
+  logger.log("Getting sdist path with version: ", version);
+  const sdistPath = `${realCwd}/dist-newstyle/sdist/${packageName}-${versionPrefix}${version}.tar.gz`;
+  logger.log("Full sdist path: ", sdistPath);
 
   logger.log("Post release candidate in hackage");
-  const status = await postReleaseCandidate(output.trim(), packageName, process.env.HACKAGE_TOKEN);
+  const status = await postReleaseCandidate(sdistPath, process.env.HACKAGE_TOKEN);
 
   if (status !== 200) {
     throw new Error(`Cannot post release candidate now, status: ${status}`);

--- a/test/unit/publish.test.ts
+++ b/test/unit/publish.test.ts
@@ -2,28 +2,27 @@ import { expect } from "@assertive-ts/core";
 import axios from "axios";
 import sinon from "sinon";
 
-import { CANDIDATES_PATH, HACKAGE_PACKAGES_URL, postReleaseCandidate } from "../../src/publish";
+import { HACKAGE_CANDIDATES_URL, postReleaseCandidate } from "../../src/publish";
 
 const sdistPath = "sdist/path";
-const packageName = "my-hackage-package";
 const hackageToken = "my-fake-token";
 
 describe("postReleaseCandidate", () => {
   it("returns the status code when request is successful", async () => {
     const axiosPostStub = sinon.stub(axios, "post").resolves({ status: 200 });
 
-    const statusCode = await postReleaseCandidate(sdistPath, packageName, hackageToken);
+    const statusCode = await postReleaseCandidate(sdistPath, hackageToken);
 
     expect(statusCode).toBeEqual(200);
     expect(axiosPostStub.calledOnce).toBeTruthy();
-    expect(axiosPostStub.firstCall.args[0]).toBeEqual(`${HACKAGE_PACKAGES_URL}/${packageName}/${CANDIDATES_PATH}`);
+    expect(axiosPostStub.firstCall.args[0]).toBeEqual(HACKAGE_CANDIDATES_URL);
   });
 
   it("throws an error on unsuccessful request", async () => {
     const errorMsg = "Error message from server";
     const axiosPostStub = sinon.stub(axios, "post").rejects({ message: errorMsg });
 
-    const request = postReleaseCandidate(sdistPath, packageName, hackageToken);
+    const request = postReleaseCandidate(sdistPath, hackageToken);
 
     await expect(request).toBeRejected();
     expect(axiosPostStub.calledOnce).toBeTruthy();


### PR DESCRIPTION
Updated `postReleaseCandidate` function and delete unnecessary code in `prepare` step