### PR TITLE
fix: publishDocumentation inside step

### DIFF
--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -37,5 +37,5 @@ export const prepare = async (
   }
 
   logger.log(output);
-  logger.success("Prepare done!");  
+  logger.success("Prepare done!");
 };

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -30,13 +30,12 @@ export const prepare = async (
   logger.log("Writing new version %s to `%s`", version, fullCabalPath);
 
   logger.log("Running cabal sdist command");
-  const { error, output } = await runExecCommand("cabal sdist");
+  const { warn, output } = await runExecCommand("cabal sdist");
 
-  if (error) {
-    logger.error(error);
-    throw new Error(error);
+  if (warn) {
+    logger.warn(warn);
   }
 
   logger.log(output);
-  logger.success("Prepare done!");
+  logger.success("Prepare done!");  
 };

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -72,11 +72,10 @@ export const publish = async (
   logger.log("Checking publishDocumentation plugin configuration: ", publishDocumentation);
   if (publishDocumentation) {
     logger.log("Generating documentation");
-    const { error, output } = await runExecCommand(V2_HADDOCK_COMMAND);
+    const { warn, output } = await runExecCommand(V2_HADDOCK_COMMAND);
 
-    if (error) {
-      logger.error(error);
-      throw new Error(error);
+    if (warn) {
+      logger.warn(warn);
     }
     logger.log(output);
     logger.log("Publishing documentation");

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,9 +1,14 @@
 import { exec } from "child_process";
 
-export const runExecCommand = (command: string): Promise<{ error: string; output: string; }> => {
+interface OutputExec {
+  output: string;
+  warn?: string;
+}
+
+export const runExecCommand = (command: string): Promise<OutputExec> => {
   return new Promise((resolve, reject) => {
     exec(command, (error, stdout, stderr) => {
-      error !== null ? reject(error) : resolve({ error: stderr, output: stdout });
+      error !== null ? reject(error) : resolve({ output: stdout, warn: stderr });
     });
   });
 };


### PR DESCRIPTION
Added `OutputExec` interface to handle better the result of the `runExecCommand` function.